### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
 website:
-  site-url: https://valentina-gonzalez.netlify.app
+  site-url: https://vgonzalezm.github.io
   page-navigation: true
   title: "Valentina Gonzalez Madariaga"
   page-footer:

--- a/docs/about.html
+++ b/docs/about.html
@@ -295,7 +295,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -335,7 +335,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -6,8 +6,8 @@
       version="2.0">
 <channel>
 <title>Valentina Gonzalez Madariaga</title>
-<link>https://valentina-gonzalez.netlify.app/blog/</link>
-<atom:link href="https://valentina-gonzalez.netlify.app/blog/index.xml" rel="self" type="application/rss+xml"/>
+<link>https://vgonzalezm.github.io/blog/</link>
+<atom:link href="https://vgonzalezm.github.io/blog/index.xml" rel="self" type="application/rss+xml"/>
 <description></description>
 <generator>quarto-1.6.37</generator>
 <lastBuildDate>Wed, 20 Aug 2025 21:08:25 GMT</lastBuildDate>

--- a/docs/index.html
+++ b/docs/index.html
@@ -243,7 +243,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/posts/2025-08-20-first-post/index.html
+++ b/docs/posts/2025-08-20-first-post/index.html
@@ -253,7 +253,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -319,7 +319,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/research.html
+++ b/docs/research.html
@@ -252,7 +252,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,1 +1,1 @@
-Sitemap: https://valentina-gonzalez.netlify.app/sitemap.xml
+Sitemap: https://vgonzalezm.github.io/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/research.html</loc>
+    <loc>https://vgonzalezm.github.io/research.html</loc>
     <lastmod>2025-08-20T21:04:11.536Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/posts/2025-08-20-first-post/index.html</loc>
+    <loc>https://vgonzalezm.github.io/posts/2025-08-20-first-post/index.html</loc>
     <lastmod>2025-08-20T21:04:11.532Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/blog/index.html</loc>
+    <loc>https://vgonzalezm.github.io/blog/index.html</loc>
     <lastmod>2025-08-20T21:05:48.453Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/about.html</loc>
+    <loc>https://vgonzalezm.github.io/about.html</loc>
     <lastmod>2025-08-20T21:05:48.452Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/index.html</loc>
+    <loc>https://vgonzalezm.github.io/index.html</loc>
     <lastmod>2025-08-20T21:05:48.544Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/projects/index.html</loc>
+    <loc>https://vgonzalezm.github.io/projects/index.html</loc>
     <lastmod>2025-08-20T21:05:48.561Z</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- update the Quarto site configuration to use the GitHub Pages domain
- add a GitHub Actions workflow that deploys the contents of `docs/` to GitHub Pages from the `main` branch
- refresh generated metadata in `docs/` so absolute URLs reference the new domain

## Testing
- `quarto render` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fe51c38d98832cac1cf4af340d464f