### PR TITLE
Document GitHub Pages deployment steps

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,36 @@
+name: Deploy site to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
 # Hi there :octocat:
 
-I am a PhD candidate in Sociology currently in the final stage of my doctoral studies.  
-My research focuses on social inequalities with a particular emphasis on care work and its intersections with paid work trajectories.  
+I am a PhD candidate in Sociology currently in the final stage of my doctoral studies.
+My research focuses on social inequalities with a particular emphasis on care work and its intersections with paid work trajectories.
 
 I am also committed to developing skills in quantitative methods and data analysis, continuously learning and applying these tools in my work.
 
 ![](https://private-user-images.githubusercontent.com/70701842/480198956-e8978313-2c2e-4e24-8f48-e19c4021df79.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTU3Mjg2MzIsIm5iZiI6MTc1NTcyODMzMiwicGF0aCI6Ii83MDcwMTg0Mi80ODAxOTg5NTYtZTg5NzgzMTMtMmMyZS00ZTI0LThmNDgtZTE5YzQwMjFkZjc5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA4MjAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwODIwVDIyMTg1MlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTFiMzllZjQ4YWY2MDc2YzNmNTgzNTJlZWQwNWQxMDg4ZjZkNjZiNTM0MzE2YjExZDJhMGYzYzZhNDMxMzgyMTkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Hr3IOig13B4GRlcdw_bxG6ffUsQiu384D0GFf_yS_o8)
+
+## Deployment
+
+The repository includes a GitHub Actions workflow in `.github/workflows/pages.yml` that uploads the pre-rendered `docs/` folder to GitHub Pages whenever you push changes to the `main` branch. To finish enabling the deployment:
+
+1. Open **Settings → Pages** in the repository.
+2. Choose **GitHub Actions** as the publishing source.
+3. Wait for the "Deploy site to GitHub Pages" workflow to complete successfully under **Actions**.
+
+Once that workflow finishes, the static files in `docs/` will be served through GitHub Pages. You can monitor the exact URL from the workflow summary—GitHub will print the published address in the deployment step.
+
+### Expected site URL
+
+- If the site lives in a repository named `vgonzalezm.github.io`, GitHub serves it directly at `https://vgonzalezm.github.io/`.
+- If you keep the Quarto source in another repository (such as this one), the published address follows the pattern `https://<tu-usuario>.github.io/<nombre-del-repo>/` (por ejemplo, `https://vgonzalezm.github.io/vsgonzalezm/`).
+
+After the first deployment, visiting the appropriate URL should show the same pages that appear under `docs/`. If you still encounter a 404 error, confirm that the GitHub Actions run succeeded and that the chosen repository matches the expected domain.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
 website:
-  site-url: https://valentina-gonzalez.netlify.app
+  site-url: https://vgonzalezm.github.io
   page-navigation: true
   title: "Valentina Gonzalez Madariaga"
   page-footer:

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+# Prevent GitHub Pages from attempting to build the pre-rendered Quarto site with Jekyll

--- a/docs/about.html
+++ b/docs/about.html
@@ -295,7 +295,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -335,7 +335,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -6,8 +6,8 @@
       version="2.0">
 <channel>
 <title>Valentina Gonzalez Madariaga</title>
-<link>https://valentina-gonzalez.netlify.app/blog/</link>
-<atom:link href="https://valentina-gonzalez.netlify.app/blog/index.xml" rel="self" type="application/rss+xml"/>
+<link>https://vgonzalezm.github.io/blog/</link>
+<atom:link href="https://vgonzalezm.github.io/blog/index.xml" rel="self" type="application/rss+xml"/>
 <description></description>
 <generator>quarto-1.6.37</generator>
 <lastBuildDate>Wed, 20 Aug 2025 21:08:25 GMT</lastBuildDate>

--- a/docs/index.html
+++ b/docs/index.html
@@ -243,7 +243,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/posts/2025-08-20-first-post/index.html
+++ b/docs/posts/2025-08-20-first-post/index.html
@@ -253,7 +253,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/projects/index.html
+++ b/docs/projects/index.html
@@ -319,7 +319,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/research.html
+++ b/docs/research.html
@@ -252,7 +252,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   }
     var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
     var mailtoRegex = new RegExp(/^mailto:/);
-      var filterRegex = new RegExp("https:\/\/valentina-gonzalez\.netlify\.app");
+      var filterRegex = new RegExp("https:\/\/vgonzalezm.github.io");
     var isInternal = (href) => {
         return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
     }

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,1 +1,1 @@
-Sitemap: https://valentina-gonzalez.netlify.app/sitemap.xml
+Sitemap: https://vgonzalezm.github.io/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/research.html</loc>
+    <loc>https://vgonzalezm.github.io/research.html</loc>
     <lastmod>2025-08-20T21:04:11.536Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/posts/2025-08-20-first-post/index.html</loc>
+    <loc>https://vgonzalezm.github.io/posts/2025-08-20-first-post/index.html</loc>
     <lastmod>2025-08-20T21:04:11.532Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/blog/index.html</loc>
+    <loc>https://vgonzalezm.github.io/blog/index.html</loc>
     <lastmod>2025-08-20T21:05:48.453Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/about.html</loc>
+    <loc>https://vgonzalezm.github.io/about.html</loc>
     <lastmod>2025-08-20T21:05:48.452Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/index.html</loc>
+    <loc>https://vgonzalezm.github.io/index.html</loc>
     <lastmod>2025-08-20T21:05:48.544Z</lastmod>
   </url>
   <url>
-    <loc>https://valentina-gonzalez.netlify.app/projects/index.html</loc>
+    <loc>https://vgonzalezm.github.io/projects/index.html</loc>
     <lastmod>2025-08-20T21:05:48.561Z</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add a `.nojekyll` sentinel file so GitHub Pages serves the rendered Quarto output as-is
- document how to finish enabling GitHub Pages and what URL to expect once the workflow publishes the site

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68fe51c38d98832cac1cf4af340d464f