### PR TITLE
Fix site URL for GitHub Pages deployment

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,7 +3,7 @@ project:
   output-dir: docs
 
 website:
-  site-url: https://vgonzalezm.github.io
+  site-url: https://vsgonzalezm.github.io
   page-navigation: true
   title: "Valentina Gonzalez Madariaga"
   page-footer:

--- a/docs/blog/index.xml
+++ b/docs/blog/index.xml
@@ -6,8 +6,8 @@
       version="2.0">
 <channel>
 <title>Valentina Gonzalez Madariaga</title>
-<link>https://vgonzalezm.github.io/blog/</link>
-<atom:link href="https://vgonzalezm.github.io/blog/index.xml" rel="self" type="application/rss+xml"/>
+<link>https://vsgonzalezm.github.io/blog/</link>
+<atom:link href="https://vsgonzalezm.github.io/blog/index.xml" rel="self" type="application/rss+xml"/>
 <description></description>
 <generator>quarto-1.6.37</generator>
 <lastBuildDate>Wed, 20 Aug 2025 21:08:25 GMT</lastBuildDate>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,1 +1,1 @@
-Sitemap: https://vgonzalezm.github.io/sitemap.xml
+Sitemap: https://vsgonzalezm.github.io/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://vgonzalezm.github.io/research.html</loc>
+    <loc>https://vsgonzalezm.github.io/research.html</loc>
     <lastmod>2025-08-20T21:04:11.536Z</lastmod>
   </url>
   <url>
-    <loc>https://vgonzalezm.github.io/posts/2025-08-20-first-post/index.html</loc>
+    <loc>https://vsgonzalezm.github.io/posts/2025-08-20-first-post/index.html</loc>
     <lastmod>2025-08-20T21:04:11.532Z</lastmod>
   </url>
   <url>
-    <loc>https://vgonzalezm.github.io/blog/index.html</loc>
+    <loc>https://vsgonzalezm.github.io/blog/index.html</loc>
     <lastmod>2025-08-20T21:05:48.453Z</lastmod>
   </url>
   <url>
-    <loc>https://vgonzalezm.github.io/about.html</loc>
+    <loc>https://vsgonzalezm.github.io/about.html</loc>
     <lastmod>2025-08-20T21:05:48.452Z</lastmod>
   </url>
   <url>
-    <loc>https://vgonzalezm.github.io/index.html</loc>
+    <loc>https://vsgonzalezm.github.io/index.html</loc>
     <lastmod>2025-08-20T21:05:48.544Z</lastmod>
   </url>
   <url>
-    <loc>https://vgonzalezm.github.io/projects/index.html</loc>
+    <loc>https://vsgonzalezm.github.io/projects/index.html</loc>
     <lastmod>2025-08-20T21:05:48.561Z</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary
- correct the Quarto `site-url` setting to use the vsgonzalezm GitHub Pages domain
- update generated sitemap, robots, and feed links to match the corrected domain

## Testing
- not run (configuration/docs update only)

------
https://chatgpt.com/codex/tasks/task_e_68fe57637634832c9a2a935c668ec31b